### PR TITLE
fix: compile on macos

### DIFF
--- a/shell.c
+++ b/shell.c
@@ -11,7 +11,7 @@
  * Return: 0
  */
 
-int main()
+int main(void)
 {
 	char *buffer;
 	int command;


### PR DESCRIPTION
This change fixes an error when trying to compile with 'gcc -Wall -Werror -Wextra -pedantic -std=gnu89 *.c -o hsh' on my version of gcc

gcc version output:
Apple clang version 15.0.0 (clang-1500.3.9.4)
Target: arm64-apple-darwin23.4.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
